### PR TITLE
Feat: DateService 객체 생성 및 Repository에 적용

### DIFF
--- a/MMM_SideProject/MMM_SideProject.xcodeproj/project.pbxproj
+++ b/MMM_SideProject/MMM_SideProject.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		267DDB762D75CBE500F66CB8 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267DDB752D75CBE500F66CB8 /* String+Extension.swift */; };
 		267DDB792D76854F00F66CB8 /* DGCharts in Frameworks */ = {isa = PBXBuildFile; productRef = 267DDB782D76854F00F66CB8 /* DGCharts */; };
 		267DDBAD2D76FE0B00F66CB8 /* TypeButtonCVCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 267DDBAC2D76FE0B00F66CB8 /* TypeButtonCVCell.swift */; };
+		26CEFAFC2D8E8D8C00616F1C /* DateService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CEFAFB2D8E8D8C00616F1C /* DateService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -115,6 +116,7 @@
 		267DDB732D75ABBD00F66CB8 /* ToastMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastMessage.swift; sourceTree = "<group>"; };
 		267DDB752D75CBE500F66CB8 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		267DDBAC2D76FE0B00F66CB8 /* TypeButtonCVCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeButtonCVCell.swift; sourceTree = "<group>"; };
+		26CEFAFB2D8E8D8C00616F1C /* DateService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -214,6 +216,7 @@
 				267DDAC92D33C94700F66CB8 /* Domain */,
 				267DD9B92D211AF800F66CB8 /* Constants */,
 				2602BF062D7EB3610002DECD /* Toast */,
+				26CEFAFA2D8E8D6100616F1C /* Utils */,
 				267DDB1A2D3BC38D00F66CB8 /* Struct */,
 				267DDB6F2D75959400F66CB8 /* Error */,
 				267DD9BC2D211AF800F66CB8 /* Font */,
@@ -334,6 +337,14 @@
 				267DDB702D7595AE00F66CB8 /* CreateError.swift */,
 			);
 			path = Error;
+			sourceTree = "<group>";
+		};
+		26CEFAFA2D8E8D6100616F1C /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				26CEFAFB2D8E8D8C00616F1C /* DateService.swift */,
+			);
+			path = Utils;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -460,6 +471,7 @@
 				267DD9CC2D211AF800F66CB8 /* UIButton+Extension.swift in Sources */,
 				267DDB392D44F3F800F66CB8 /* GraphViewModel.swift in Sources */,
 				267DDB712D7595AE00F66CB8 /* CreateError.swift in Sources */,
+				26CEFAFC2D8E8D8C00616F1C /* DateService.swift in Sources */,
 				267DDAFB2D37EE8200F66CB8 /* DataRepository.swift in Sources */,
 				267DD9D32D211AF800F66CB8 /* DetailViewController.swift in Sources */,
 				267DDAB82D338ED100F66CB8 /* CalendarCoordinator.swift in Sources */,

--- a/MMM_SideProject/MMM_SideProject/Domain/DataRepository.swift
+++ b/MMM_SideProject/MMM_SideProject/Domain/DataRepository.swift
@@ -13,7 +13,7 @@ final class DataRepository : DataRepositoryInterface {
     // MARK: - CalendarVM 에서 사용하는 repository에서는 항상 total 타입
     private var stateType : ButtonType = .total
     
-    private var dateType : YearMonthDay = .init()
+    private var dateService : DateService = .init()
     
     private var cellIconList : [CreateCellIcon] = .init()
     
@@ -39,7 +39,7 @@ final class DataRepository : DataRepositoryInterface {
         
         let realmData = realm.objects(UserDB.self)
         
-        return realmData.where { $0.dateString == dateType.toStringYearMonthDay() }
+        return realmData.where { $0.dateString == dateService.yearmonthday }
             .map { Entity(id: $0.id, dateStr: $0.dateString, typeStr: $0.typeString , createType: $0.createType, amount: $0.moneyAmount, iconImage: $0.iconImageType.getImage) }
     }
     
@@ -55,7 +55,7 @@ final class DataRepository : DataRepositoryInterface {
         if typeName == "" { tempTypeName = readMostTypeName() }
         
         return realm.objects(UserDB.self)
-            .filter("dateString BEGINSWITH '\(dateType.toStringYearMonthForRealmData())' AND createType == 'expend' AND typeString == '\(tempTypeName)'")
+            .filter("dateString BEGINSWITH '\(dateService.yearmonthComparison)' AND createType == 'expend' AND typeString == '\(tempTypeName)'")
             .map { Entity(id: $0.id, dateStr: $0.dateString, typeStr: $0.typeString, createType: $0.createType, amount: $0.moneyAmount, iconImage: $0.iconImageType.getImage)}
             .sorted {
                 $0.dateStr > $1.dateStr
@@ -63,7 +63,7 @@ final class DataRepository : DataRepositoryInterface {
     }
     
     func readDate() -> String {
-        return dateType.toStringYearMonth()
+        return dateService.yearmonth
     }
     
     func readAmountsDict() -> [String : Int] {
@@ -97,7 +97,7 @@ final class DataRepository : DataRepositoryInterface {
             return []
         }
         
-        let userDB = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateType.toStringYearMonthForRealmData())'")
+        let userDB = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateService.yearmonthComparison)'")
             .where { $0.createType == .expend }
         
         var tempDict : [String : Double] = .init()
@@ -168,10 +168,10 @@ final class DataRepository : DataRepositoryInterface {
     func setDate(type : DateButtonType) {
         switch type {
         case .increase:
-            dateType.increase()
+            dateService.increase()
             return
         case .decrease:
-            dateType.decrease()
+            dateService.decrease()
             return
         }
     }
@@ -185,12 +185,12 @@ final class DataRepository : DataRepositoryInterface {
             return
         }
         
-        dateType.setYear(of: year)
-        dateType.setMonth(of: month)
+        dateService.setYear(of: year)
+        dateService.setMonth(of: month)
     }
     
     func setDay(of day : Int) {
-        dateType.setDay(of: day)
+        dateService.setDay(of: day)
     }
     
     func deleteData(id: UUID) {
@@ -216,7 +216,7 @@ private extension DataRepository {
             return []
         }
         
-        let realmData = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateType.toStringYearMonthForRealmData())'")
+        let realmData = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateService.yearmonthComparison)'")
         
         return realmData.sorted { $0.dateString > $1.dateString }
             .map { Entity(id: $0.id, dateStr: $0.dateString, typeStr: $0.typeString , createType: $0.createType, amount: $0.moneyAmount, iconImage: $0.iconImageType.getImage) }
@@ -228,7 +228,7 @@ private extension DataRepository {
             return []
         }
         
-        let realmData = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateType.toStringYearMonthForRealmData())'")
+        let realmData = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateService.yearmonthComparison)'")
             .where { $0.createType == .income }
         
         return realmData.sorted { $0.dateString > $1.dateString }
@@ -241,7 +241,7 @@ private extension DataRepository {
             return []
         }
         
-        let realmData = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateType.toStringYearMonthForRealmData())'")
+        let realmData = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateService.yearmonthComparison)'")
             .where { $0.createType == .expend }
         
         return realmData.sorted { $0.dateString > $1.dateString }
@@ -254,7 +254,7 @@ private extension DataRepository {
             return ""
         }
         
-        let realmData = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateType.toStringYearMonthForRealmData())'")
+        let realmData = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateService.yearmonthComparison)'")
             .where { $0.createType == .expend }
             
         var tempDict : [String : Double] = .init()

--- a/MMM_SideProject/MMM_SideProject/Domain/MockDataRepository.swift
+++ b/MMM_SideProject/MMM_SideProject/Domain/MockDataRepository.swift
@@ -13,7 +13,7 @@ final class MockDataRepository : DataRepositoryInterface {
     // MARK: - CalendarVM 에서 사용하는 repository에서는 항상 total 타입
     private var stateType : ButtonType = .total
     
-    private var dateType : YearMonthDay = .init()
+    private var dateService : DateService = .init()
     
     private var cellIconList : [CreateCellIcon] = .init()
     
@@ -39,7 +39,7 @@ final class MockDataRepository : DataRepositoryInterface {
         
         let realmData = realm.objects(UserDB.self)
         
-        return realmData.where { $0.dateString == dateType.toStringYearMonthDay() }
+        return realmData.where { $0.dateString == dateService.yearmonthday }
             .map { Entity(id: $0.id, dateStr: $0.dateString, typeStr: $0.typeString , createType: $0.createType, amount: $0.moneyAmount, iconImage: $0.iconImageType.getImage) }
     }
     
@@ -55,7 +55,7 @@ final class MockDataRepository : DataRepositoryInterface {
         if typeName == "" { tempTypeName = readMostTypeName() }
         
         return realm.objects(UserDB.self)
-            .filter("dateString BEGINSWITH '\(dateType.toStringYearMonthForRealmData())' AND createType == 'expend' AND typeString == '\(tempTypeName)'")
+            .filter("dateString BEGINSWITH '\(dateService.yearmonthComparison)' AND createType == 'expend' AND typeString == '\(tempTypeName)'")
             .map { Entity(id: $0.id, dateStr: $0.dateString, typeStr: $0.typeString, createType: $0.createType, amount: $0.moneyAmount, iconImage: $0.iconImageType.getImage)}
             .sorted {
                 $0.dateStr > $1.dateStr
@@ -63,7 +63,7 @@ final class MockDataRepository : DataRepositoryInterface {
     }
     
     func readDate() -> String {
-        return dateType.toStringYearMonth()
+        return dateService.yearmonth
     }
     
     func readAmountsDict() -> [String : Int] {
@@ -97,7 +97,7 @@ final class MockDataRepository : DataRepositoryInterface {
             return []
         }
         
-        let userDB = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateType.toStringYearMonthForRealmData())'")
+        let userDB = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateService.yearmonthComparison)'")
             .where { $0.createType == .expend }
         
         var tempDict : [String : Double] = .init()
@@ -168,10 +168,10 @@ final class MockDataRepository : DataRepositoryInterface {
     func setDate(type : DateButtonType) {
         switch type {
         case .increase:
-            dateType.increase()
+            dateService.increase()
             return
         case .decrease:
-            dateType.decrease()
+            dateService.decrease()
             return
         }
     }
@@ -185,12 +185,12 @@ final class MockDataRepository : DataRepositoryInterface {
             return
         }
         
-        dateType.setYear(of: year)
-        dateType.setMonth(of: month)
+        dateService.setYear(of: year)
+        dateService.setMonth(of: month)
     }
     
     func setDay(of day : Int) {
-        dateType.setDay(of: day)
+        dateService.setDay(of: day)
     }
     
     func deleteData(id: UUID) {
@@ -216,7 +216,7 @@ private extension MockDataRepository {
             return []
         }
         
-        let realmData = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateType.toStringYearMonthForRealmData())'")
+        let realmData = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateService.yearmonthComparison)'")
         
         return realmData.sorted { $0.dateString > $1.dateString }
             .map { Entity(id: $0.id, dateStr: $0.dateString, typeStr: $0.typeString , createType: $0.createType, amount: $0.moneyAmount, iconImage: $0.iconImageType.getImage) }
@@ -228,7 +228,7 @@ private extension MockDataRepository {
             return []
         }
         
-        let realmData = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateType.toStringYearMonthForRealmData())'")
+        let realmData = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateService.yearmonthComparison)'")
             .where { $0.createType == .income }
         
         return realmData.sorted { $0.dateString > $1.dateString }
@@ -241,7 +241,7 @@ private extension MockDataRepository {
             return []
         }
         
-        let realmData = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateType.toStringYearMonthForRealmData())'")
+        let realmData = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateService.yearmonthComparison)'")
             .where { $0.createType == .expend }
         
         return realmData.sorted { $0.dateString > $1.dateString }
@@ -254,7 +254,7 @@ private extension MockDataRepository {
             return ""
         }
         
-        let realmData = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateType.toStringYearMonthForRealmData())'")
+        let realmData = realm.objects(UserDB.self).filter("dateString BEGINSWITH '\(dateService.yearmonthComparison)'")
             .where { $0.createType == .expend }
             
         var tempDict : [String : Double] = .init()

--- a/MMM_SideProject/MMM_SideProject/Utils/DateService.swift
+++ b/MMM_SideProject/MMM_SideProject/Utils/DateService.swift
@@ -1,0 +1,52 @@
+//
+//  DateService.swift
+//  MMM_SideProject
+//
+//  Created by 강대훈 on 3/22/25.
+//
+
+import UIKit
+
+struct DateService {
+    private var ymd = YearMonthDay()
+    
+    /// YYYY-MM-DD 형식으로 반환해주는 계산 속성
+    var yearmonthday : String {
+        "\(ymd.getYear())-\(ymd.getMonth() < 10 ? "0" + String(ymd.getMonth()) : String(ymd.getMonth()))-\(ymd.getDay() < 10 ? "0" + String(ymd.getDay()) : String(ymd.getDay()))"
+    }
+    
+    /// YYYY년 MM월 형식으로 반환해주는 계산 속성
+    var yearmonth : String {
+        "\(ymd.getYear())년 \(ymd.getMonth())월"
+    }
+    
+    /// YYYY-MM 형식으로 반환해주는 계산 속성 (DB와의 조건 비교)
+    var yearmonthComparison : String {
+        return "\(ymd.getYear())-\(ymd.getMonth() < 10 ? "0" + String(ymd.getMonth()) : String(ymd.getMonth()))"
+    }
+    
+    /// 1개월을 감소시키는 메소드
+    mutating func decrease() {
+        ymd.decrease()
+    }
+    
+    /// 1개월을 증가시키는 메소드
+    mutating func increase() {
+        ymd.increase()
+    }
+    
+    /// 날짜를 수정하는 메소드
+    mutating func setDay(of day : Int) {
+        ymd.setDay(of: day)
+    }
+    
+    /// 개월을 수정하는 메소드
+    mutating func setMonth(of month : Int) {
+        ymd.setMonth(of: month)
+    }
+    
+    /// 년도를 수정하는 메소드
+    mutating func setYear(of year : Int) {
+        ymd.setYear(of: year)
+    }
+}


### PR DESCRIPTION
#문제
---
`YearMonthDay` 에 넘은 많은 책임이 부여되어 있었기에 `DateService` 객체를 통해서 메세지를 주고 받는 형식으로 변경.

DataRepository에서 직접 YearMonthDay 타입을 가져와서 쓰는 것에서 DateService를 사용하도록 변경.

- [x] #58 

resolved: #58 